### PR TITLE
Fix React Router docs URLs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,9 +14,9 @@ import Layout from "@layouts/Layout";
  * @returns Componente de React que renderiza la aplicación
  * @example
  * <App />
- * @see https://reactrouter.com/web/api/Routes
- * @see https://reactrouter.com/web/api/Route
- */
+ * @see https://reactrouter.com/en/main/components/routes
+ * @see https://reactrouter.com/en/main/components/route
+*/
 const App = () => {
   console.log(
     "%cBienvenido a la aplicación de " +

--- a/src/layouts/Layout.jsx
+++ b/src/layouts/Layout.jsx
@@ -7,8 +7,8 @@ import Navbar from "@components/Navbar";
  * @returns Componente de React que renderiza el layout de la aplicación
  * @example
  * <Layout />
- * @see https://reactrouter.com/web/api/Outlet
- */
+ * @see https://reactrouter.com/en/main/components/outlet
+*/
 const Layout = () => {
   return (
     <div className="bg-light">

--- a/src/pages/Episodios.jsx
+++ b/src/pages/Episodios.jsx
@@ -14,8 +14,8 @@ const getEpisode = (episodeString) => ({
  * @returns Componente de React que renderiza la página de episodios
  * @example
  * <Episodios />
- * @see https://reactrouter.com/web/api/Hooks/useparams
- */
+ * @see https://reactrouter.com/en/main/hooks/use-params
+*/
 const Episodios = () => {
   // Obtenemos el parámetro de la URL
   const params = useParams();

--- a/src/pages/Personajes.jsx
+++ b/src/pages/Personajes.jsx
@@ -9,7 +9,7 @@ import Pagination from "@components/Pagination";
  * @returns Componente de React que renderiza la página de personajes
  * @example
  * <Personajes />
- * @see https://reactrouter.com/web/api/Hooks/useparams
+ * @see https://reactrouter.com/en/main/hooks/use-params
  * @see https://reactjs.org/docs/hooks-reference.html#useeffect
  * @see https://reactjs.org/docs/hooks-reference.html#usestate
  */


### PR DESCRIPTION
## Summary
- update links in App.jsx JSDoc to React Router v6 documentation
- adjust Layout.jsx JSDoc Outlet reference
- refresh Personajes.jsx and Episodios.jsx JSDoc `useParams` links

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6861435ecac0832a9aa2c8741e7ca210